### PR TITLE
Más caras para el dado

### DIFF
--- a/application/controllers/Main.php
+++ b/application/controllers/Main.php
@@ -1535,7 +1535,12 @@ class Main extends CI_Controller {
 			$this->analytics->event('Telegram', 'Games', 'Dice');
 			$can = $pokemon->settings($telegram->chat->id, 'play_games');
 			if($can != FALSE or $can === NULL){
-				$joke = "*" .mt_rand(1,6) ."*";
+                $numeroCaras = filter_var($telegram->last_word(), FILTER_SANITIZE_NUMBER_INT);
+                $carasDado = 6;
+                if(is_numeric($numeroCaras) && ($numeroCaras == 4 or $numeroCaras == 6 or $numeroCaras == 8 or $numeroCaras == 10 or $numeroCaras == 12 or $numeroCaras == 20 or $numeroCaras === 100){
+                    $carasDado = $numeroCaras;
+                }
+				$joke = "*" .mt_rand(1,$carasDado) ."*";
 			}
 		}elseif(
 			( $telegram->text_has("piedra") and


### PR DESCRIPTION
Hola a todos!
Como, durante gran parte de mi vida, he sido un enfermo del rol (ya se me va pasando), se me ha ocurrido añadirle al profesor la posibilidad de tirar el dado eligiendo las caras al final de la solicitud (ej: "/dado 8" o "tira el dado de 8"
Los dados de rol que conozco tienen 4, 6, 8, 10, 12, 20 y 100 caras.
Si no se especifican las caras, por defecto serán 6.
Es una modificación chorra, pero he pensado que mejor no romper nada la primera vez que contribuya.
¿Qué os parece?
Saludos.