### PR TITLE
Solo avisar no verificado/kickeado si no hay grupo admin

### DIFF
--- a/application/plugins/base_newuser.php
+++ b/application/plugins/base_newuser.php
@@ -176,10 +176,6 @@ if($telegram->is_chat_group() && $telegram->data_received() == "new_chat_partici
 				$pokemon->user_delgroup($new->id, $telegram->chat->id);
 				$str = "Usuario " .$new->first_name ." / " .$new->id ." kickeado por no estar verificado.";
 			}
-			$telegram->send
-				->text($str)
-			->send();
-
 			if($adminchat){
 				$str = ":warning: Usuario no validado.\n"
 						.":id: " .$new->id ."\n"
@@ -189,6 +185,11 @@ if($telegram->is_chat_group() && $telegram->data_received() == "new_chat_partici
 					->notification(TRUE)
 					->chat($adminchat)
 					->text($str)
+				->send();
+			}
+			else{
+				$telegram->send
+				->text($str)
 				->send();
 			}
             return -1;

--- a/application/plugins/base_newuser.php
+++ b/application/plugins/base_newuser.php
@@ -186,10 +186,9 @@ if($telegram->is_chat_group() && $telegram->data_received() == "new_chat_partici
 					->chat($adminchat)
 					->text($str)
 				->send();
-			}
-			else{
+			}else{
 				$telegram->send
-				->text($str)
+					->text($str)
 				->send();
 			}
             return -1;


### PR DESCRIPTION
Es bastante molesto en los grupos que requieren verificación que la misma persona esté intentando entrar todo el rato y Oak lo esté narrando. Creo que si tienes un grupo de admin, ya lo ves por ahí y no debería salir por el grupo normal. Si acaso se le pondría enviar por privado a los registrados no verificados (cosa que no hace este miniparche). ¿Qué opinas?