### PR TITLE
Pequeñas mejoras para la creación de raids

### DIFF
--- a/application/plugins/base_functions.php
+++ b/application/plugins/base_functions.php
@@ -71,8 +71,8 @@ function time_parse($string){
         if(!isset($data['hour']) and in_array($w, ["la", "las"])){ $waiting_time = TRUE; }
         if(!isset($data['hour']) and $w == "en"){ $waiting_time_add = TRUE; }
 
-        if(is_numeric($w) or (in_array(strlen($w), [2,3]) && substr($w, -1) == "h")){
-            $number = (int) $w;
+        if(is_int($w) or (in_array(strlen($w), [2,3]) && substr($w, -1) == "h")){
+            $number = (int) abs($w);
             if($waiting_time){
                 if($number >= 24){ continue; }
                 if($number <= 6){ $number = $number + 12; }
@@ -82,7 +82,7 @@ function time_parse($string){
             continue;
         }
 
-        if(!isset($data['hour']) && preg_match("/(\d\d?):(\d\d)/", $w, $hour)){
+        if(!isset($data['hour']) && preg_match("/(\d\d?)[:.](\d\d)/", $w, $hour)){
             if($hour[1] >= 24){ $hour[1] = "00"; }
             if($hour[2] >= 60){ $hour[2] = "00"; }
             $data['hour'] = "$hour[1]:$hour[2]";

--- a/application/plugins/raid.php
+++ b/application/plugins/raid.php
@@ -22,10 +22,10 @@ if($this->telegram->is_chat_group() or $this->telegram->key == "channel_post"){
 		$place = NULL;
 		if($this->telegram->text_has("en")){
 			$pos = strpos($this->telegram->text(), " en ") + strlen(" en ");
-            $place = substr($this->telegram->text(), $pos);
-            if(!$this->telegram->text_has(["termina", "acaba"], ["a las"])){
-                $place = preg_replace("/ a las \d\d[:.]\d\d$/", "", $place);
-            }
+			$place = substr($this->telegram->text(), $pos);
+			if(!$this->telegram->text_has(["termina", "acaba"], ["a las"])){
+				$place = preg_replace("/ a las \d\d[:.]\d\d$/", "", $place);
+			}
 		}
 		if(empty($place) and $this->telegram->words() > 5){ return; }
 

--- a/application/plugins/raid.php
+++ b/application/plugins/raid.php
@@ -16,13 +16,16 @@ if(!in_array(date("H"), range(8, 21))){
 if($this->telegram->is_chat_group() or $this->telegram->key == "channel_post"){
 
 	if(
-		$this->telegram->text_has(["montar", "monta", "crear", "organizar", "organiza"], ["raid", "incursión"]) and
+		$this->telegram->text_has(["montar", "monta", "crear", "organizar", "organiza", "nueva"], ["raid", "incursión", "#raid"]) and
 		$this->telegram->words() <= 20
 	){
 		$place = NULL;
 		if($this->telegram->text_has("en")){
 			$pos = strpos($this->telegram->text(), " en ") + strlen(" en ");
-			$place = substr($this->telegram->text(), $pos);
+            $place = substr($this->telegram->text(), $pos);
+            if(!$this->telegram->text_has(["termina", "acaba"], ["a las"])){
+                $place = preg_replace("/ a las \d\d[:.]\d\d$/", "", $place);
+            }
 		}
 		if(empty($place) and $this->telegram->words() > 5){ return; }
 


### PR DESCRIPTION
He añadido unas pequeñas mejoras para la creación de raids. Revísalas y si ves que son positivas, yo creo que estaría bien metarlas.

Los cambios en `base_functions.php`:

Son las tres líneas para poder aceptar el formato de hora 12.00 o 13.15 (usando un punto en vez de dos). Te sorprenderías la cantidad de gente que pone así la hora cuando crea raids.

Los cambios en `raid.php` son dos:

1. Permitir la palabra `nueva` y `#raid` (como lo pone Oak) para crear raids. Hay gente que no lee nada y lo intenta poner así.

2. Eliminar la hora del lugar si se pone la hora al final. Hay mucha gente que por mucho que se le diga pone "Crear raid de P en L a las H", en vez de seguir el orden recomendado. Al final, Oak, duplica la hora (porque la incluye tanto en la variable de la hora como en la de lugar) y pone "Nueva #raid de P a las H en L a las H". Hay gente que pone al final cuándo acaba la raid, y por eso detecto si la persona no pone las palabras "termina" o "acaba", y además solo lo reemplazo si se pone al final de todo.


