### PR TITLE
Hacer que /kick y /ban funcionen desde el grupo admin

### DIFF
--- a/application/plugins/group_admin.php
+++ b/application/plugins/group_admin.php
@@ -139,7 +139,8 @@ if($telegram->text_command(["kick", "ban"])){
             }
 			if($q !== FALSE){
 				$pokemon->user_delgroup($kick, $chat);
-				$adminchat = $this->pokemon->settings($this->telegram->chat->id, 'admin_chat');
+				$adminchat = $pokemon->is_group_admin($chat);
+				if(empty($adminchat)){ $adminchat = $this->pokemon->settings($this->telegram->chat->id, 'admin_chat'); }
 				if($adminchat){
 					if($telegram->text_contains("kick")){
 						$str = ":forbid: Usuario kickeado\n";

--- a/application/plugins/group_admin.php
+++ b/application/plugins/group_admin.php
@@ -111,8 +111,10 @@ if($step == "CUSTOM_COMMAND"){
 // Echar usuario del grupo
 if($telegram->text_command(["kick", "ban"])){
     $admins = $pokemon->telegram_admins(TRUE);
+    $chat = $pokemon->is_group_admin($this->telegram->chat->id);
+    if(empty($chat)){ $chat = $this->telegram->chat->id; }
 
-    if(in_array($telegram->user->id, $admins)){ // Tiene que ser admin
+    if($pokemon->is_group_admin($this->telegram->chat->id) or in_array($telegram->user->id, $admins)){ // Tiene que ser admin
         $kick = NULL;
         if($telegram->has_reply){
             $kick = $telegram->reply_user->id;
@@ -130,13 +132,13 @@ if($telegram->text_command(["kick", "ban"])){
 			$q = FALSE;
             if($telegram->text_contains("kick")){
                 $this->analytics->event('Telegram', 'Kick');
-                $q = $telegram->send->kick($kick, $telegram->chat->id);
+                $q = $telegram->send->kick($kick, $chat);
             }elseif($telegram->text_contains("ban")){
                 $this->analytics->event('Telegram', 'Ban');
-                $q = $telegram->send->ban($kick, $telegram->chat->id);
+                $q = $telegram->send->ban($kick, $chat);
             }
 			if($q !== FALSE){
-				$pokemon->user_delgroup($kick, $telegram->chat->id);
+				$pokemon->user_delgroup($kick, $chat);
 				$adminchat = $this->pokemon->settings($this->telegram->chat->id, 'admin_chat');
 				if($adminchat){
 					if($telegram->text_contains("kick")){

--- a/application/plugins/group_admin.php
+++ b/application/plugins/group_admin.php
@@ -139,8 +139,7 @@ if($telegram->text_command(["kick", "ban"])){
             }
 			if($q !== FALSE){
 				$pokemon->user_delgroup($kick, $chat);
-				$adminchat = $pokemon->is_group_admin($chat);
-				if(empty($adminchat)){ $adminchat = $this->pokemon->settings($this->telegram->chat->id, 'admin_chat'); }
+				$adminchat = $this->pokemon->settings($chat, 'admin_chat');
 				if($adminchat){
 					if($telegram->text_contains("kick")){
 						$str = ":forbid: Usuario kickeado\n";


### PR DESCRIPTION
La mayoría de los comandos ya funcionan desde el grupo admin, pero curiosamente /kick y /ban no lo hacen (mientras que `/unban` sí funciona!).

Este parche hace que `/kick` y `/ban` actúen sobre el grupo general si estás en el grupo admin. Por favor, revísalo ya que no he podido probarlo adecuadamente, aunque solo son 3 líneas.

El código es básicamente el mismo que en `group_kick.php` así que no he inventado mucho, he usado los mismos nombres de variables y todo.