### PR TITLE
Contestar nido sin interrogación si <= 5 palabras

### DIFF
--- a/application/plugins/pokemon_nest.php
+++ b/application/plugins/pokemon_nest.php
@@ -53,10 +53,13 @@ function check_reset_nest(){
 // if(!$this->telegram->text_contains("nido")){ return; } // HACK TODO Cambiar frases para la gente?
 
 if(
-    (
-		$telegram->text_has(["donde", "conocéis", "sabéis", "sabe", "cual"]) &&
-	    $telegram->text_contains(["visto", "encontra", "encuentro", "está", "aparece", "hay", "salen", "sale", "nido"]) && $telegram->text_contains("?") &&
-	    $telegram->words() <= 10
+	(
+		(
+			$telegram->text_has(["donde", "conocéis", "sabéis", "sabe", "cual"]) &&
+			$telegram->text_contains(["visto", "encontra", "encuentro", "está", "aparece", "hay", "salen", "sale", "nido"])
+		) && (
+			($telegram->text_contains("?") && $telegram->words() <= 10) or $telegram->words() <= 5
+		)
 	) or (
 		$telegram->text_has("Y", TRUE) and
 		$telegram->text_contains("?") and


### PR DESCRIPTION
Muchas otras preguntas no requieren interrogación, pero preguntar dónde hay un nido si. He añadido una condición para que conteste a dónde está un nido si <= 5 palabras, aunque la frase no lleve interrogación.

Eso hará que funcionen frases como `dónde hay electabuzz` o `dónde puedo encontrar a pikachu`