### PR TITLE
Evitar que una pregunta 'dónde está el pan?' se registre como petición de nido

### DIFF
--- a/application/plugins/pokemon_nest.php
+++ b/application/plugins/pokemon_nest.php
@@ -76,6 +76,10 @@ if(
 		$adminchat and
 		!$this->pokemon->settings($this->telegram->chat->id, 'disable_nest_log')
 	){
+		$text = $telegram->text();
+		$pk = pokemon_parse($text);
+		if(empty($pk['pokemon'])){ return; }
+
 		$chatinfo = $this->db
 			->where('uid', $this->telegram->user->id)
 			->where('cid', $this->telegram->chat->id)
@@ -145,6 +149,10 @@ if(
 		$adminchat and
 		!$this->pokemon->settings($this->telegram->chat->id, 'disable_nest_log')
 	){
+		$text = $telegram->text();
+		$pk = pokemon_parse($text);
+		if(empty($pk['pokemon'])){ return; }
+
 		$chatinfo = $this->db
 			->where('uid', $this->telegram->user->id)
 			->where('cid', $this->telegram->chat->id)


### PR DESCRIPTION
Me lo ha pedido raru. Resulta que si cualquiera pregunta "Dónde tal y pascual?" y no dice un pokémon, se registra como petición de nido, porque esos trozos de código nunca piden que haya un pokémon válido.

(Nota: No lo he podido probar, porque no sé cómo desplegar el bot, así que te pediría que lo pruebes tú... he intentado tener cuidado pero ya se sabe que hasta que se prueban las cosas...)